### PR TITLE
Clean code in light-apps

### DIFF
--- a/packages/light-apps/src/Content/Content.tsx
+++ b/packages/light-apps/src/Content/Content.tsx
@@ -3,23 +3,18 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import React from 'react';
-import { withRouter, RouteComponentProps } from 'react-router';
+import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { Container, IdentityCard } from '@polkadot/ui-components';
 import { inject, observer } from 'mobx-react';
 
-import routing from '../routing';
-import NotFound from './NotFound';
-import Onboarding from '../Onboarding';
-import { OnboardingStoreInterface } from '../stores/interfaces';
+import { NotFound } from './NotFound';
+import { Onboarding } from '../Onboarding';
+import { routing } from '../routing';
+import { OnboardingStore } from '../stores/onboardingStore';
 
-type Props = RouteComponentProps & {
-  onboardingStore?: OnboardingStoreInterface
-};
-
-const unknown = {
-  Component: NotFound,
-  name: ''
-};
+interface Props extends RouteComponentProps {
+  onboardingStore: OnboardingStore;
+}
 
 const ID_CARD_ACTIONS = (name: string) => {
   switch (name) {
@@ -28,26 +23,22 @@ const ID_CARD_ACTIONS = (name: string) => {
         'value': 'Transfer Balance',
         'to': 'Transfer'
       };
-      break;
     case 'Transfer':
       return {
         'value': 'Manage Accounts',
         'to': 'Identity'
       };
-      break;
     default:
       return {
         'value': 'Transfer Balance',
         'to': 'Transfer'
       };
-      break;
   }
 };
 
-@(withRouter as any)
 @inject('onboardingStore')
 @observer
-class Content extends React.Component<Props> {
+export class Content extends React.Component<Props> {
   handleRouteChange = (to?: string) => {
     const { history, location } = this.props;
 
@@ -60,26 +51,24 @@ class Content extends React.Component<Props> {
   }
 
   render () {
-    const { location, onboardingStore } = this.props;
-
-    const app = location.pathname.slice(1) || '';
-    const { Component, name } = routing.routes.find((route) =>
-      !!(route && app.indexOf(route.name) === 0)
-    ) || unknown;
+    const { onboardingStore } = this.props;
 
     return (
       <Container>
         {
-          onboardingStore!.isFirstRun
-          ? <Onboarding {...({} as RouteComponentProps<any>)} />
-          : <div>
+          onboardingStore.isFirstRun
+            ? <Route component={Onboarding} />
+            : <React.Fragment>
               <IdentityCard
                 address={'7qroA7r5Ky9FHN5mXA2GNxZ79ieStv4WYYjYe3m3XszK9SvF'}
                 goToRoute={this.handleRouteChange}
                 value={ID_CARD_ACTIONS(name)['value']}
-                />
-              <Component basePath={`/${name}`} />
-            </div>
+              />
+              <Switch>
+                {routing.routes.map(route => <Route key={route.name} path={route.path} component={route.Component} />)}
+                <Route component={NotFound} />
+              </Switch>
+            </React.Fragment>
         }
       </Container>
     );
@@ -88,5 +77,3 @@ class Content extends React.Component<Props> {
 
 // FIXME:
 // address should come from Keyring
-
-export default Content;

--- a/packages/light-apps/src/Content/NotFound.tsx
+++ b/packages/light-apps/src/Content/NotFound.tsx
@@ -3,15 +3,13 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import React from 'react';
-import { Redirect } from 'react-router';
+import { Redirect } from 'react-router-dom';
 
-import routing from '../routing';
+import { routing } from '../routing';
 
-type Props = {};
+const defaultTo = routing.default.path;
 
-const defaultTo = `/${routing.default}`;
-
-export default class NotFound extends React.PureComponent<Props> {
+export class NotFound extends React.PureComponent {
   render () {
     return (
       <Redirect to={defaultTo} />

--- a/packages/light-apps/src/Content/index.ts
+++ b/packages/light-apps/src/Content/index.ts
@@ -2,8 +2,4 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-export interface OnboardingStoreInterface {
-  isFirstRun?: boolean;
-  setIsFirstRun: (isFirstRun: boolean) => void;
-  updateLS: () => void;
-}
+export * from './Content';

--- a/packages/light-apps/src/Onboarding/Onboarding.tsx
+++ b/packages/light-apps/src/Onboarding/Onboarding.tsx
@@ -119,7 +119,7 @@ export class Onboarding extends React.Component<Props, State> {
       onboardingStore
     } = this.props;
 
-    onboardingStore!.setIsFirstRun(false);
+    onboardingStore.setIsFirstRun(false);
 
     // FIXME: restoreAccount account with light-api
 

--- a/packages/light-apps/src/Onboarding/Onboarding.tsx
+++ b/packages/light-apps/src/Onboarding/Onboarding.tsx
@@ -2,21 +2,21 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import React from 'react';
-import { withRouter, RouteComponentProps } from 'react-router';
 import { inject, observer } from 'mobx-react';
+import React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
 import keyring from '@polkadot/ui-keyring';
 import { u8aToString } from '@polkadot/util';
 import { mnemonicGenerate, mnemonicToSeed, naclKeypairFromSeed } from '@polkadot/util-crypto';
 import { AddressSummary, Container, FadedText, Input, InputFile, Modal, NavButton, NavLink, Segment, Stacked } from '@polkadot/ui-components';
 
-import { OnboardingStoreInterface } from '../stores/interfaces';
+import { OnboardingStore } from '../stores/onboardingStore';
 
-type Props = RouteComponentProps & {
-  onboardingStore?: OnboardingStoreInterface
-};
+interface Props extends RouteComponentProps {
+  onboardingStore: OnboardingStore;
+}
 
-type OnboardingScreenType = 'importOptions' | 'save' | 'new' ;
+type OnboardingScreenType = 'importOptions' | 'save' | 'new';
 
 type State = {
   address?: string,
@@ -41,7 +41,6 @@ function generateAddressFromSeed (seed: string): string {
   );
 }
 
-@(withRouter as any)
 @inject('onboardingStore')
 @observer
 export class Onboarding extends React.Component<Props, State> {
@@ -100,8 +99,8 @@ export class Onboarding extends React.Component<Props, State> {
     const { screen } = this.state;
     this.setState({
       screen: screen === 'new' || screen === 'save'
-                ? 'importOptions'
-                : 'new',
+        ? 'importOptions'
+        : 'new',
       password: ''
     });
   }
@@ -137,11 +136,11 @@ export class Onboarding extends React.Component<Props, State> {
         size='tiny'
       >
         <Container>
-          { screen === 'new'
-              ? this.renderNewAccountScreen()
-              : screen === 'importOptions'
-                ? this.renderImportOptionsScreen()
-                : this.renderSaveScreen()
+          {screen === 'new'
+            ? this.renderNewAccountScreen()
+            : screen === 'importOptions'
+              ? this.renderImportOptionsScreen()
+              : this.renderSaveScreen()
           }
         </Container>
       </Modal>
@@ -204,7 +203,7 @@ export class Onboarding extends React.Component<Props, State> {
 
     return (
       <React.Fragment>
-        <Modal.SubHeader> { screen === 'save' ? 'Decrypt your account with your passphrase' : 'Encrypt it with a passphrase' } </Modal.SubHeader>
+        <Modal.SubHeader> {screen === 'save' ? 'Decrypt your account with your passphrase' : 'Encrypt it with a passphrase'} </Modal.SubHeader>
         <Input
           onChange={this.onChangePassword}
           value={password}
@@ -218,7 +217,7 @@ export class Onboarding extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <Modal.SubHeader> Restore Account from JSON Backup File </Modal.SubHeader>
-        <InputFile onChange={this.handleFileUploaded}/>
+        <InputFile onChange={this.handleFileUploaded} />
       </React.Fragment>
     );
   }

--- a/packages/light-apps/src/Onboarding/index.ts
+++ b/packages/light-apps/src/Onboarding/index.ts
@@ -2,6 +2,4 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Onboarding } from './Onboarding';
-
-export default Onboarding;
+export * from './Onboarding';

--- a/packages/light-apps/src/createApp.tsx
+++ b/packages/light-apps/src/createApp.tsx
@@ -6,7 +6,6 @@ import { ProviderInterface } from '@polkadot/rpc-provider/types';
 import { RpcRxInterface } from '@polkadot/rpc-rx/types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { HashRouter } from 'react-router-dom';
 
 type Props = {
   api?: RpcRxInterface,
@@ -22,9 +21,7 @@ export function createApp (App: React.ComponentType, props: Props = {}, rootId: 
   }
 
   ReactDOM.render(
-    <HashRouter>
-      <App />
-    </HashRouter>,
+    <App />,
     rootElement
   );
 }

--- a/packages/light-apps/src/createApp.tsx
+++ b/packages/light-apps/src/createApp.tsx
@@ -14,7 +14,7 @@ type Props = {
   url?: string
 };
 
-export function createApp (App: React.ComponentType, { api, provider, url }: Props = {}, rootId: string = 'root'): void {
+export function createApp (App: React.ComponentType, props: Props = {}, rootId: string = 'root'): void {
   const rootElement = document.getElementById(rootId);
 
   if (!rootElement) {

--- a/packages/light-apps/src/index.tsx
+++ b/packages/light-apps/src/index.tsx
@@ -5,7 +5,7 @@
 import substrateLogo from '@polkadot/ui-assets/parity-substrate.svg';
 import { Provider } from 'mobx-react';
 import React from 'react';
-import { NavLink, Route } from 'react-router-dom';
+import { HashRouter, NavLink, Route } from 'react-router-dom';
 import 'semantic-ui-css/semantic.min.css';
 
 import { Content } from './Content';
@@ -15,19 +15,21 @@ import * as rootStore from './stores';
 
 function App () {
   return (
-    <div>
-      <GlobalStyle />
-      <NavLink to='/'>
-        <img
-          src={substrateLogo}
-          height={100}
-          width={150}
-        />
-      </NavLink>
-      <Provider {...rootStore}>
-        <Route path='/' component={Content} />
-      </Provider>
-    </div>
+    <HashRouter>
+      <div>
+        <GlobalStyle />
+        <NavLink to='/'>
+          <img
+            src={substrateLogo}
+            height={100}
+            width={150}
+          />
+        </NavLink>
+        <Provider {...rootStore}>
+          <Route path='/' component={Content} />
+        </Provider>
+      </div>
+    </HashRouter>
   );
 }
 

--- a/packages/light-apps/src/index.tsx
+++ b/packages/light-apps/src/index.tsx
@@ -3,42 +3,31 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import React from 'react';
-import { RouteComponentProps } from 'react-router';
-import { NavLink } from 'react-router-dom';
+import { NavLink, Route } from 'react-router-dom';
 import { Provider } from 'mobx-react';
-import settings from '@polkadot/ui-settings';
 import substrateLogo from '@polkadot/ui-assets/parity-substrate.svg';
 import 'semantic-ui-css/semantic.min.css';
 
+import { Content } from './Content';
 import { createApp } from './createApp';
 import { GlobalStyle } from './globalStyle';
-import Content from './Content';
-import rootStore from './stores';
+import * as rootStore from './stores';
 
-const LOGO = substrateLogo;
-
-type Props = {};
-
-function App (props: Props) {
+function App () {
   return (
-    <div >
+    <div>
       <GlobalStyle />
-      <NavLink to={'/'}>
+      <NavLink to='/'>
         <img
-          src={LOGO}
+          src={substrateLogo}
           height={100}
           width={150}
         />
       </NavLink>
       <Provider {...rootStore}>
-        <Content {...({} as RouteComponentProps<any>)} />
+        <Route path='/' component={Content} />
       </Provider>
     </div>
   );
 }
-
-const url = !settings.apiUrl
-  ? undefined
-  : settings.apiUrl;
-
-createApp(App, { url });
+createApp(App);

--- a/packages/light-apps/src/index.tsx
+++ b/packages/light-apps/src/index.tsx
@@ -2,10 +2,10 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import substrateLogo from '@polkadot/ui-assets/parity-substrate.svg';
+import { Provider } from 'mobx-react';
 import React from 'react';
 import { NavLink, Route } from 'react-router-dom';
-import { Provider } from 'mobx-react';
-import substrateLogo from '@polkadot/ui-assets/parity-substrate.svg';
 import 'semantic-ui-css/semantic.min.css';
 
 import { Content } from './Content';
@@ -30,4 +30,5 @@ function App () {
     </div>
   );
 }
+
 createApp(App);

--- a/packages/light-apps/src/routing/identity.tsx
+++ b/packages/light-apps/src/routing/identity.tsx
@@ -6,12 +6,10 @@ import { Route } from '../types';
 
 import { Identity } from '@polkadot/identity-app';
 
-export default (
-  {
-    Component: Identity,
-    icon: 'users',
-    isApiGated: true,
-    isHidden: false,
-    name: 'Identity'
-  }
-) as Route;
+export const identity: Route = {
+  Component: Identity,
+  icon: 'users',
+  isApiGated: true,
+  isHidden: false,
+  name: 'Identity'
+};

--- a/packages/light-apps/src/routing/identity.tsx
+++ b/packages/light-apps/src/routing/identity.tsx
@@ -11,5 +11,6 @@ export const identity: Route = {
   icon: 'users',
   isApiGated: true,
   isHidden: false,
-  name: 'Identity'
+  name: 'Identity',
+  path: '/Identity'
 };

--- a/packages/light-apps/src/routing/index.tsx
+++ b/packages/light-apps/src/routing/index.tsx
@@ -9,6 +9,6 @@ import { Routing } from '../types';
 const routes = [identity, transfer];
 
 export const routing = {
-  default: 'Identity',
+  default: identity,
   routes
 } as Routing;

--- a/packages/light-apps/src/routing/index.tsx
+++ b/packages/light-apps/src/routing/index.tsx
@@ -2,17 +2,13 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Routing, Routes } from '../types';
+import { identity } from './identity';
+import { transfer } from './transfer';
+import { Routing } from '../types';
 
-import identity from './identity';
-import transfer from './transfer';
+const routes = [identity, transfer];
 
-const routes: Routes = ([] as Routes).concat(
-                          identity,
-                          transfer
-                       );
-
-export default ({
+export const routing = {
   default: 'Identity',
   routes
-} as Routing);
+} as Routing;

--- a/packages/light-apps/src/routing/transfer.tsx
+++ b/packages/light-apps/src/routing/transfer.tsx
@@ -2,16 +2,14 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Routes } from '../types';
+import { Route } from '../types';
 
 import { Transfer } from '@polkadot/transfer-app';
 
-export default ([
-  {
-    Component: Transfer,
-    icon: 'angle double right',
-    isApiGated: true,
-    isHidden: false,
-    name: 'Transfer'
-  }
-] as Routes);
+export const transfer: Route = {
+  Component: Transfer,
+  icon: 'angle double right',
+  isApiGated: true,
+  isHidden: false,
+  name: 'Transfer'
+};

--- a/packages/light-apps/src/routing/transfer.tsx
+++ b/packages/light-apps/src/routing/transfer.tsx
@@ -11,5 +11,6 @@ export const transfer: Route = {
   icon: 'angle double right',
   isApiGated: true,
   isHidden: false,
-  name: 'Transfer'
+  name: 'Transfer',
+  path: '/Transfer'
 };

--- a/packages/light-apps/src/stores/index.d.ts
+++ b/packages/light-apps/src/stores/index.d.ts
@@ -1,5 +1,0 @@
-import { OnboardingStoreInterface } from './interfaces';
-
-declare module 'stores' {
-    export function onboardingStore (): OnboardingStoreInterface;
-}

--- a/packages/light-apps/src/stores/index.ts
+++ b/packages/light-apps/src/stores/index.ts
@@ -2,8 +2,4 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import onboardingStore from './onboardingStore';
-
-export default {
-  onboardingStore
-};
+export { onboardingStore } from './onboardingStore';

--- a/packages/light-apps/src/stores/onboardingStore.ts
+++ b/packages/light-apps/src/stores/onboardingStore.ts
@@ -6,12 +6,10 @@ import { action, observable } from 'mobx';
 import store from 'store';
 import { enableLogging } from 'mobx-logger';
 
-import { OnboardingStoreInterface } from './interfaces';
-
 const LS_KEY = `__substrate-light::firstRun`;
 const NODE_ENV = process.env.NODE_ENV;
 
-export class OnboardingStore implements OnboardingStoreInterface {
+export class OnboardingStore {
   @observable
   isFirstRun?: boolean;
 
@@ -38,4 +36,4 @@ export class OnboardingStore implements OnboardingStoreInterface {
   updateLS = () => store.set(LS_KEY, this.isFirstRun);
 }
 
-export default new OnboardingStore();
+export const onboardingStore = new OnboardingStore();

--- a/packages/light-apps/src/types.ts
+++ b/packages/light-apps/src/types.ts
@@ -13,12 +13,11 @@ export type Route = {
   icon: SemanticICONS,
   isApiGated: boolean,
   isHidden: boolean,
-  name: string
+  name: string,
+  path: string
 };
 
-export type Routes = Array<Route | null>;
-
 export type Routing = {
-  default: string,
-  routes: Routes
+  default: Route,
+  routes: Route[]
 };


### PR DESCRIPTION
- Remove some TS `as any`
- Remove `onboardingStore!.something`
- Use named exports
- Use `<Route>` component instead of writing the logic ourselves