### PR TITLE
Package electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ As of now, the main functions are as follows, in order of priority:
 
 Make sure you have [yarn >= 1.4.2](http://yarnpkg.com/) and [nodejs >= 10.10.0](https://nodejs.org/en/).
 
-**IMPORTANT.** For now, you also need to have an instance of [Substrate](https://github.com/paritytech/substrate) running locally on your machine, exposing a WebSocket on its default port 127.0.0.1:9944. We plan of course to bundle Substrate into the Electron app very soon, see #52.
+**IMPORTANT.** For now, you also need to have an instance of [Substrate](https://github.com/paritytech/substrate) running locally on your machine, exposing a WebSocket on its default port 127.0.0.1:9944. We plan of course to bundle Substrate into the Electron app very soon, see [#52](https://github.com/paritytech/substrate-light-ui/issues/52).
 
 ### Clone this repo
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# light-ui
-Light client focused user interface for the Polkadot network. It is currently being built as an Electron app, and will be migrated to a web app once wasm compilation of the Substrate Light node is available.
+# substrate-light-ui
 
-### Overview
-This is the repository for Substrate light client's user interface. The light-ui is meant to be an intuitive interface for beginner users to easily be able to interact with the main components of various Substrate chains. This UI builds upon Gavin Wood's live demo from the 2018 Web3 Summit: https://youtu.be/0IoUZdDi5Is?t=3858
+Light client focused user interface for the Polkadot and Substrate networks. It is currently being built as an Electron app, and will be migrated to a web app once wasm compilation of the Substrate Light node is available.
+
+## Overview
+
+This is the repository for Substrate light client's user interface. The light-ui is meant to be an intuitive interface for beginner users to easily be able to interact with the main components of various Substrate chains.
 
 As of now, the main functions are as follows, in order of priority:
 
@@ -12,11 +14,38 @@ As of now, the main functions are as follows, in order of priority:
 
 * Staking/Nominating/Voting democracy - stake tokens, nominate validators, and vote for proposals regarding the the current chain.
 
-### How to run
-```
+## Build from sources
+
+### Dependencies
+
+Make sure you have [yarn >= 1.4.2](http://yarnpkg.com/) and [nodejs >= 10.10.0](https://nodejs.org/en/).
+
+For now, you also need to have an instance of [Substrate](https://github.com/paritytech/substrate) running locally on your machine. We plan of course to bundle Substrate into the Electron app very soon.
+
+### Clone this repo
+
+```bash
 git clone https://github.com/paritytech/substrate-light-ui
-cd substrate-light-ui
-nvm use stable
-yarn
+cd ./substrate-light-ui
+yarn install
+```
+
+### Build this repo and run
+
+```bash
+yarn electron
+```
+
+### Build binaries (takes more time)
+
+```bash
+yarn package
+```
+
+### Run with live reload for development
+
+```bash
 yarn start
 ```
+
+> Troubleshooting: If it hangs on a white screen in Electron even though it has compiled and has been syncing for a long time, then simply choose 'View > Reload' (CMD + R on macOS) from the Electron menu. If the menu is not shown in the tray, then by clicking the Electron window and then holding down the ALT key to reveal it.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ As of now, the main functions are as follows, in order of priority:
 
 Make sure you have [yarn >= 1.4.2](http://yarnpkg.com/) and [nodejs >= 10.10.0](https://nodejs.org/en/).
 
-For now, you also need to have an instance of [Substrate](https://github.com/paritytech/substrate) running locally on your machine. We plan of course to bundle Substrate into the Electron app very soon.
+**IMPORTANT.** For now, you also need to have an instance of [Substrate](https://github.com/paritytech/substrate) running locally on your machine, exposing a WebSocket on its default port 127.0.0.1:9944. We plan of course to bundle Substrate into the Electron app very soon, see #52.
 
 ### Clone this repo
 
@@ -36,7 +36,9 @@ yarn install
 yarn electron
 ```
 
-### Build binaries (takes more time)
+### Build binaries
+
+This command takes more time than the previous, but it'll produce a fully standalone binary.
 
 ```bash
 yarn package

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
   "workspaces": {
     "packages": [
       "packages/*"
+    ],
+    "nohoist": [
+      "**/electron-builder",
+      "**/electron-builder/**",
+      "**/electron-webpack",
+      "**/electron-webpack/**"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,32 +1,25 @@
 {
   "name": "@polkadot/light-ui",
-  "description": "User interface optimized for the Substrate light client",
   "version": "0.1.0",
-  "private": true,
+  "author": "Parity Technologies <admin@parity.io>",
+  "description": "User interface optimized for the Substrate light client",
   "license": "Apache-2.0",
-  "author": "Parity Team <admin@parity.io>",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/paritytech/substrate-light-ui.git"
-  },
+  "private": true,
+  "repository": "https://github.com/paritytech/substrate-light-ui.git",
   "workspaces": {
     "packages": [
       "packages/*"
-    ],
-    "nohoist": [
-      "**/electron-builder",
-      "**/electron-builder/**",
-      "**/electron-webpack",
-      "**/electron-webpack/**"
     ]
   },
   "scripts": {
     "prebuild": "yarn clean",
-    "prepackage": "yarn build",
-    "package": "cd packages/electron-app && yarn dist",
     "build": "lerna exec yarn build --stream",
     "clean": "polkadot-dev-clean-build",
+    "preelectron": "yarn build",
+    "electron": "cd packages/electron-app && yarn electron",
     "lint": "tsc --noEmit && tslint --project .",
+    "prepackage": "yarn build",
+    "package": "cd packages/electron-app && yarn package",
     "prestart": "./scripts/prestart.sh",
     "start": "lerna exec yarn start --parallel",
     "test": "CI=true lerna run test --parallel"

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   "scripts": {
     "prebuild": "yarn clean",
     "prepackage": "yarn build",
-    "prestart": "./scripts/prestart.sh",
     "package": "cd packages/electron-app && yarn dist",
     "build": "lerna exec yarn build --stream",
     "clean": "polkadot-dev-clean-build",
     "lint": "tsc --noEmit && tslint --project .",
+    "prestart": "./scripts/prestart.sh",
     "start": "lerna exec yarn start --parallel",
     "test": "CI=true lerna run test --parallel"
   },

--- a/packages/electron-app/README.md
+++ b/packages/electron-app/README.md
@@ -1,0 +1,13 @@
+# electron-app
+
+Build an Electron application, using `electron-webpack` and `electron-builder`.
+
+## How it works
+
+### `yarn build`
+
+This command assumes that we've built a CRA app inside `packages/light-apps`. It will copy the built files into electron-webpack's `static/` folder, and tell Electron to serve these files.
+
+### `yarn start`
+
+Runs `electron-webpack dev`, which tells Electron to load http://localhost:3000, which is most likely the port on which CRA's dev mode runs. It reloads Electron on any code change inside the electron codebase.

--- a/packages/electron-app/electron-builder.json
+++ b/packages/electron-app/electron-builder.json
@@ -1,0 +1,21 @@
+{
+  "appId": "io.parity.substratelightui",
+  "linux": {
+    "category": "Utility",
+    "target": [
+      "AppImage",
+      "snap",
+      "deb",
+      "tar.xz"
+    ]
+  },
+  "mac": {
+    "category": "public.app-category.productivity"
+  },
+  "productName": "Parity Substrate Light UI",
+  "publish": "github",
+  "win": {
+    "publisherName": "Parity Technologies (UK) Ltd.",
+    "target": "nsis"
+  }
+}

--- a/packages/electron-app/package.json
+++ b/packages/electron-app/package.json
@@ -5,32 +5,12 @@
   "license": "Apache-2.0",
   "private": true,
   "repository": "https://github.com/paritytech/substrate-light-ui.git",
-  "build": {
-    "appId": "io.parity.substratelightui",
-    "linux": {
-      "category": "Utility",
-      "target": [
-        "AppImage",
-        "snap",
-        "deb",
-        "tar.xz"
-      ]
-    },
-    "mac": {
-      "category": "public.app-category.productivity"
-    },
-    "productName": "Parity Substrate Light UI",
-    "publish": "github",
-    "win": {
-      "publisherName": "Parity Technologies (UK) Ltd.",
-      "target": "nsis"
-    }
-  },
   "scripts": {
+    "prebuild": "copyfiles -u 2 \"../light-apps/build/**/*\" static/",
     "build": "electron-webpack",
     "electron": "electron dist/main/main.js",
     "dist": "yarn build && electron-builder",
-    "start": "cross-env ELECTRON_START_URL=http://localhost:3000 electron-webpack dev --ws-origins all",
+    "start": "cross-env ELECTRON_START_URL=http://localhost:3000 electron-webpack dev",
     "test": "echo Skipped."
   },
   "devDependencies": {
@@ -38,13 +18,13 @@
     "copyfiles": "^2.0.0",
     "cross-env": "^5.2.0",
     "electron": "^4.0.0",
-    "electron-builder": "^20.38.4",
-    "electron-devtools-installer": "^2.2.4",
-    "electron-webpack": "^2.6.1",
+    "electron-builder": "^20.38.5",
+    "electron-webpack": "^2.6.2",
     "electron-webpack-ts": "^3.1.1",
     "webpack": "^4.28.3"
   },
   "dependencies": {
-    "@types/electron-devtools-installer": "^2.2.0"
+    "@types/electron-devtools-installer": "^2.2.0",
+    "electron-devtools-installer": "^2.2.4"
   }
 }

--- a/packages/electron-app/package.json
+++ b/packages/electron-app/package.json
@@ -10,7 +10,7 @@
     "prebuild": "copyfiles -u 2 \"../light-apps/build/**/*\" static/",
     "build": "electron-webpack",
     "electron": "electron dist/main/main.js",
-    "dist": "yarn build && electron-builder",
+    "package": "electron-builder",
     "start": "cross-env ELECTRON_START_URL=http://localhost:3000 electron-webpack dev",
     "test": "echo Skipped."
   },
@@ -22,6 +22,7 @@
     "electron-builder": "^20.38.5",
     "electron-webpack": "^2.6.2",
     "electron-webpack-ts": "^3.1.1",
+    "source-map-support": "^0.5.10",
     "webpack": "^4.28.3"
   },
   "dependencies": {

--- a/packages/electron-app/package.json
+++ b/packages/electron-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@substrate/electron-app",
   "version": "0.1.0",
+  "author": "Parity Technologies <admin@parity.io>",
   "description": "Substrate Light UI",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/electron-app/package.json
+++ b/packages/electron-app/package.json
@@ -22,11 +22,11 @@
     "electron-builder": "^20.38.5",
     "electron-webpack": "^2.6.2",
     "electron-webpack-ts": "^3.1.1",
-    "source-map-support": "^0.5.10",
     "webpack": "^4.28.3"
   },
   "dependencies": {
     "@types/electron-devtools-installer": "^2.2.0",
-    "electron-devtools-installer": "^2.2.4"
+    "electron-devtools-installer": "^2.2.4",
+    "source-map-support": "^0.5.10"
   }
 }

--- a/packages/electron-app/src/main/index.ts
+++ b/packages/electron-app/src/main/index.ts
@@ -4,9 +4,13 @@
 
 import electron from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
+import path from 'path';
+import url from 'url';
+
+import { staticPath } from './util/staticPath';
 
 const { app, BrowserWindow } = electron;
-let mainWindow: Electron.BrowserWindow | null;
+let mainWindow: Electron.BrowserWindow | undefined;
 
 function createWindow () {
   mainWindow = new BrowserWindow({
@@ -16,7 +20,11 @@ function createWindow () {
   });
 
   mainWindow.loadURL(
-    process.env.ELECTRON_START_URL || 'http://127.0.0.1:3000'
+    process.env.ELECTRON_START_URL || url.format({
+      pathname: path.join(staticPath, 'build', 'index.html'),
+      protocol: 'file:',
+      slashes: true
+    })
   );
 
   if (process.env.NODE_ENV !== 'production') {
@@ -26,14 +34,25 @@ function createWindow () {
   }
 
   mainWindow.on('closed', () => {
-    mainWindow = null;
+    mainWindow = undefined;
   });
 }
 
 app.on('ready', createWindow);
 
-app.on('activate', () => {
-  if (mainWindow === null) {
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === undefined) {
     createWindow();
+  }
+});
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit();
   }
 });

--- a/packages/electron-app/src/main/util/staticPath.ts
+++ b/packages/electron-app/src/main/util/staticPath.ts
@@ -1,0 +1,17 @@
+// Copyright 2018-2019 @paritytech/substrate-light-ui authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+declare var __static: string;
+
+// Is our app packaged in a binary or still in Electron?
+const appIsPackaged = !process.defaultApp;
+
+/**
+ * Get the path to the `static` folder.
+ *
+ * @see https://github.com/electron-userland/electron-webpack/issues/52
+ */
+export const staticPath = appIsPackaged
+  ? __dirname.replace(/app\.asar$/, 'static')
+  : __static;

--- a/packages/electron-app/src/main/util/staticPath.ts
+++ b/packages/electron-app/src/main/util/staticPath.ts
@@ -9,8 +9,10 @@ const appIsPackaged = !process.defaultApp;
 
 /**
  * Get the path to the `static` folder.
+ * This is a temporary hack, waiting for the 2 issues to be fixed.
  *
  * @see https://github.com/electron-userland/electron-webpack/issues/52
+ * @see https://github.com/electron-userland/electron-webpack/issues/157
  */
 export const staticPath = appIsPackaged
   ? __dirname.replace(/app\.asar$/, 'static')

--- a/packages/electron-app/src/main/util/staticPath.ts
+++ b/packages/electron-app/src/main/util/staticPath.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-declare var __static: string;
+import path from 'path';
 
 // Is our app packaged in a binary or still in Electron?
 const appIsPackaged = !process.defaultApp;
@@ -14,4 +14,4 @@ const appIsPackaged = !process.defaultApp;
  */
 export const staticPath = appIsPackaged
   ? __dirname.replace(/app\.asar$/, 'static')
-  : __static;
+  : path.join(process.cwd(), 'static');

--- a/packages/identity-app/package.json
+++ b/packages/identity-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@substrate/identity-app",
   "version": "0.1.0",
+  "author": "Parity Technologies <admin@parity.io>",
   "description": "Account management for Substrate client",
   "license": "Apache-2.0",
   "main": "build/index.js",

--- a/packages/light-apps/package.json
+++ b/packages/light-apps/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@substrate/light-apps",
   "version": "0.1.0",
+  "author": "Parity Technologies <admin@parity.io>",
   "description": "User interface optimized for the Substrate light client",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/light-apps/package.json
+++ b/packages/light-apps/package.json
@@ -17,6 +17,7 @@
     "not ie <= 11",
     "not op_mini all"
   ],
+  "homepage": "./",
   "dependencies": {
     "@polkadot/api": "^0.42.2",
     "@polkadot/keyring": "^0.33.36",

--- a/packages/transfer-app/package.json
+++ b/packages/transfer-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@substrate/transfer-app",
   "version": "0.1.0",
+  "author": "Parity Technologies <admin@parity.io>",
   "description": "Basic app for transfering balances",
   "license": "Apache-2.0",
   "main": "build/index.js",

--- a/packages/ui-api/package.json
+++ b/packages/ui-api/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@substrate/ui-api",
+  "author": "Parity Technologies <admin@parity.io>",
   "version": "0.1.0",
   "description": "Wrapper to connect React components to PolkadotJS Api",
   "license": "Apache-2.0",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@substrate/ui-components",
   "version": "0.1.0",
+  "author": "Parity Technologies <admin@parity.io>",
   "description": "UI components shared across Substrate Light UI",
   "license": "Apache-2.0",
   "main": "build/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,6 +2696,11 @@ ajv-keywords@^3.0.0, ajv-keywords@^3.1.0, ajv-keywords@^3.2.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
   integrity sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
 
+ajv-keywords@^3.2.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
+  integrity sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
+
 ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
@@ -2705,6 +2710,16 @@ ajv@^4.9.1:
     json-stable-stringify "^1.0.1"
 
 ajv@^6.0.1, ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.5, ajv@^6.7.0:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.1.tgz#a4d3683d74abc5670e75f0b16520f70a20ea8dc1"
+  integrity sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.7.0:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.1.tgz#a4d3683d74abc5670e75f0b16520f70a20ea8dc1"
   integrity sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==
@@ -5817,7 +5832,7 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
   integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
 
-electron-builder@^20.38.4:
+electron-builder@^20.38.5:
   version "20.38.5"
   resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.38.5.tgz#31b3913a68b4911afd4cfc7bcd2522c5808040cd"
   integrity sha512-p88IDHhH2J4hA6KwRBJY+OfVZuFtFIShY3Uh/TwYAfbX0v1RhKZytuGdO8sty2zcWxDYX74xDBv+X9oN6qEIRQ==
@@ -5910,7 +5925,7 @@ electron-webpack-ts@^3.1.1:
     fork-ts-checker-webpack-plugin "^0.5.2"
     ts-loader "^5.3.3"
 
-electron-webpack@^2.6.1:
+electron-webpack@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/electron-webpack/-/electron-webpack-2.6.2.tgz#6727944eef2a6dc8e483e34e5da756903c501965"
   integrity sha512-/bl9FIRrk5/zCP0MyRB10sqHCIFWsuAF0QvhkS0kb+b7ezRCeY6ru8c0vO5kVt76XZY72JsVYEwPqrarAz36Zg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,11 +2696,6 @@ ajv-keywords@^3.0.0, ajv-keywords@^3.1.0, ajv-keywords@^3.2.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
   integrity sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
 
-ajv-keywords@^3.2.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
-  integrity sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
-
 ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
@@ -2710,16 +2705,6 @@ ajv@^4.9.1:
     json-stable-stringify "^1.0.1"
 
 ajv@^6.0.1, ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.5, ajv@^6.7.0:
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.1.tgz#a4d3683d74abc5670e75f0b16520f70a20ea8dc1"
-  integrity sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==
-  dependencies:
-    fast-deep-equal "^2.0.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.7.0:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.1.tgz#a4d3683d74abc5670e75f0b16520f70a20ea8dc1"
   integrity sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==
@@ -4906,7 +4891,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-subscription@^16.8.0, create-subscription@^16.8.1:
+create-subscription@^16.8.0:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/create-subscription/-/create-subscription-16.8.1.tgz#2466ae5eb11c74b8d00edc34c615fa5af5782386"
   integrity sha512-bQBvp8znMEVbWj8Z8Acc3a1j/Axvdx3hkTriKjeJuriPlRjwyY9ReGB8mbTavQmnflSDORB6XTLYO6V1WUsY/w==
@@ -13135,7 +13120,7 @@ react-error-overlay@^5.1.0:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.3.tgz#16fcbde75ed4dc6161dc6dc959b48e92c6ffa9ad"
   integrity sha512-GoqeM3Xadie7XUApXOjkY3Qhs8RkwB/Za4WMedBGrOKH1eTuKGyoAECff7jiVonJchOx6KZ9i8ILO5XIoHB+Tg==
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.6.0, react-is@^16.8.1:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.1.tgz#a80141e246eb894824fb4f2901c0c50ef31d4cdb"
   integrity sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA==


### PR DESCRIPTION
Add Electron packaging, so that anyone who stumbles across this repo can easily start playing with it. Relates to #27.

To test, make sure the 3 commands work from the root folder:
- yarn start: as usual, dev mode
- yarn electron: run Electron with the bundled React app
- yarn package: build binary