### PR TITLE
Send Balance

### DIFF
--- a/packages/identity-app/src/SavedAccounts.tsx
+++ b/packages/identity-app/src/SavedAccounts.tsx
@@ -2,11 +2,11 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AddressSummary, MarginTop, Stacked, WalletCard, WithSpace } from '@substrate/ui-components';
+import { AddressSummary, BalanceDisplay, MarginTop, Stacked, WalletCard, WithSpace } from '@substrate/ui-components';
 import accountObservable from '@polkadot/ui-keyring/observable/accounts';
 import { SingleAddress, SubjectInfo } from '@polkadot/ui-keyring/observable/types';
+import { ApiContext, Subscribe } from '@substrate/ui-api';
 import { map } from 'rxjs/operators';
-import { Subscribe } from 'react-with-observable';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
@@ -15,6 +15,10 @@ type Props = {
 };
 
 export class SavedAccounts extends React.PureComponent<Props> {
+  static contextType = ApiContext;
+
+  context!: React.ContextType<typeof ApiContext>; // http://bit.ly/typescript-and-react-context
+
   render () {
     return (
       <WalletCard
@@ -31,6 +35,8 @@ export class SavedAccounts extends React.PureComponent<Props> {
   }
 
   renderAllAccountsFromKeyring () {
+    const { api } = this.context;
+
     return (
       <Subscribe>
         {accountObservable.subject.pipe(
@@ -45,11 +51,22 @@ export class SavedAccounts extends React.PureComponent<Props> {
                     orientation='horizontal'
                     size='small'
                   />
+                  <Subscribe>
+                    {
+                      // FIXME using any because freeBalance gives a Codec here, not a Balance
+                      // Wait for @polkadot/api to have TS support for all query.*
+                      api.query.balances.freeBalance(account.json.address).pipe(map(this.renderBalance as any))
+                    }
+                  </Subscribe>
                 </Link>
               </React.Fragment>
             )
           ))}
       </Subscribe>
     );
+  }
+
+  renderBalance = (balance: Balance) => {
+    return <BalanceDisplay balance={balance} />;
   }
 }

--- a/packages/identity-app/src/SavedAccounts.tsx
+++ b/packages/identity-app/src/SavedAccounts.tsx
@@ -2,6 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { Balance } from '@polkadot/types';
 import { AddressSummary, BalanceDisplay, MarginTop, Stacked, WalletCard, WithSpace } from '@substrate/ui-components';
 import accountObservable from '@polkadot/ui-keyring/observable/accounts';
 import { SingleAddress, SubjectInfo } from '@polkadot/ui-keyring/observable/types';

--- a/packages/transfer-app/src/Saved.tsx
+++ b/packages/transfer-app/src/Saved.tsx
@@ -90,6 +90,7 @@ export class Saved extends React.PureComponent<Props> {
                       orientation='horizontal'
                       size='64'
                       />
+                    </Link>
                     <Subscribe>
                       {
                         // FIXME using any because freeBalance gives a Codec here, not a Balance
@@ -97,7 +98,6 @@ export class Saved extends React.PureComponent<Props> {
                         api.query.balances.freeBalance(account.json.address).pipe(map(this.renderBalance as any))
                       }
                     </Subscribe>
-                    </Link>
                   </React.Fragment>
               )
           ))}
@@ -124,14 +124,14 @@ export class Saved extends React.PureComponent<Props> {
                           name={address.json.meta.name}
                           orientation='horizontal'
                           size='small' />
-                          <Subscribe>
-                            {
-                              // FIXME using any because freeBalance gives a Codec here, not a Balance
-                              // Wait for @polkadot/api to have TS support for all query.*
-                              api.query.balances.freeBalance(address.json.address).pipe(map(this.renderBalance as any))
-                            }
-                          </Subscribe>
                       </Link>
+                      <Subscribe>
+                        {
+                          // FIXME using any because freeBalance gives a Codec here, not a Balance
+                          // Wait for @polkadot/api to have TS support for all query.*
+                          api.query.balances.freeBalance(address.json.address).pipe(map(this.renderBalance as any))
+                        }
+                      </Subscribe>
                       <Link to='#' data-address={address.json.address} onClick={this.forgetSelectedAddress}>
                         <Icon name='close' />
                       </Link>

--- a/packages/transfer-app/src/Saved.tsx
+++ b/packages/transfer-app/src/Saved.tsx
@@ -1,12 +1,12 @@
 // Copyright 2018-2019 @paritytech/substrate-light-ui authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
-
-import { ApiContext, Subscribe } from '@substrate/ui-api';
-import { AddressSummary, BalanceDisplay, Grid, Icon, MarginTop, NavLink, Stacked, StackedHorizontal, SubHeader, WalletCard, WithSpace } from '@substrate/ui-components';
+import { Balance } from '@polkadot/types';
 import { SingleAddress, SubjectInfo } from '@polkadot/ui-keyring/observable/types';
 import accountObservable from '@polkadot/ui-keyring/observable/accounts';
 import addressObservable from '@polkadot/ui-keyring/observable/addresses';
+import { ApiContext, Subscribe } from '@substrate/ui-api';
+import { AddressSummary, BalanceDisplay, Grid, Icon, MarginTop, NavLink, Stacked, StackedHorizontal, SubHeader, WalletCard, WithSpace } from '@substrate/ui-components';
 import React from 'react';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { map } from 'rxjs/operators';
@@ -88,7 +88,7 @@ export class Saved extends React.PureComponent<Props> {
                       address={account.json.address}
                       name={account.json.meta.name}
                       orientation='horizontal'
-                      size='64'
+                      size='medium'
                       />
                     </Link>
                     <Subscribe>

--- a/packages/transfer-app/src/SendBalance.tsx
+++ b/packages/transfer-app/src/SendBalance.tsx
@@ -1,10 +1,13 @@
 // Copyright 2018-2019 @paritytech/substrate-light-ui authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
+import ApiRx from '@polkadot/api/rx';
+// import { Nonce } from '@polkadot/api/types';
 import { ApiContext } from '@substrate/ui-api';
 import { AddressSummary, Grid, Header, Icon, Input, MarginTop, NavButton, Stacked } from '@substrate/ui-components';
 import BN from 'bn.js';
 import React from 'react';
+import { first, switchMap } from 'rxjs/operators';
 import { Step } from 'semantic-ui-react';
 import { RouteComponentProps } from 'react-router-dom';
 
@@ -66,8 +69,24 @@ export class SendBalance extends React.PureComponent<Props, State> {
     });
   }
 
-  onSubmitTransfer = () => {
-    // FIXME: handle transfer
+  onSubmitTransfer = async () => {
+    const { amount, recipientAddress } = this.state;
+    const { match } = this.props;
+
+    const api = await ApiRx.create().toPromise();
+
+    const sender = match.params.currentAddress;
+
+    api.tx.balances
+      .transfer(recipientAddress, amount)
+      .signAndSend(sender)
+      .subscribe(({ status, type }) => {
+        if (type === 'Finalised') {
+          console.log(`Successful transfer of ${amount} from ${sender} to ${recipientAddress} with hash ${status.asFinalised.toHex()}`);
+        } else {
+          console.log(`Staus of transfer: ${type}`);
+        }
+      });
   }
 
   openSelectAccountsModal = () => {

--- a/packages/transfer-app/src/SendBalance.tsx
+++ b/packages/transfer-app/src/SendBalance.tsx
@@ -7,7 +7,6 @@ import { ApiContext } from '@substrate/ui-api';
 import { AddressSummary, Grid, Header, Icon, Input, MarginTop, NavButton, Stacked } from '@substrate/ui-components';
 import BN from 'bn.js';
 import React from 'react';
-import { first, switchMap } from 'rxjs/operators';
 import { Step } from 'semantic-ui-react';
 import { RouteComponentProps } from 'react-router-dom';
 

--- a/packages/transfer-app/src/SendBalance.tsx
+++ b/packages/transfer-app/src/SendBalance.tsx
@@ -2,7 +2,6 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 import ApiRx from '@polkadot/api/rx';
-import { Nonce } from '@polkadot/api/types';
 import { ApiContext } from '@substrate/ui-api';
 import { AddressSummary, ErrorText, Grid, Header, Icon, Input, MarginTop, NavButton, Stacked, SuccessText } from '@substrate/ui-components';
 import BN from 'bn.js';
@@ -10,7 +9,7 @@ import React from 'react';
 import { Step } from 'semantic-ui-react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Subscription } from 'rxjs';
-import { first, map, switchMap } from 'rxjs/operators';
+import { first, switchMap } from 'rxjs/operators';
 
 import { Saved } from './Saved';
 
@@ -103,7 +102,7 @@ export class SendBalance extends React.PureComponent<Props, State> {
         .pipe(
            first(),
            // pipe nonce into transfer
-           switchMap(nonce =>
+           switchMap((nonce: any) =>
              api.tx.balances
                // create transfer
                .transfer(recipientAddress, amount)
@@ -114,11 +113,13 @@ export class SendBalance extends React.PureComponent<Props, State> {
            )
         )
         // subscribe to overall result
+        // @ts-ignore
+        // FIXME: add the status and type types
         .subscribe(({ status, type }) => {
           if (type === 'Finalised') {
             this.onSuccess(`Completed at block hash ${status.asFinalised.toHex()}`);
           } else if (type === 'Dropped' || type === 'Usurped') {
-            this.onError(`${type} at ${status.asFinalised.toHex}`);
+            this.onError(`${type} at ${status}`);
           } else {
             console.log(`Status of transfer: ${type}...`);
           }

--- a/packages/transfer-app/src/SendBalance.tsx
+++ b/packages/transfer-app/src/SendBalance.tsx
@@ -4,11 +4,12 @@
 import ApiRx from '@polkadot/api/rx';
 import { Nonce } from '@polkadot/api/types';
 import { ApiContext } from '@substrate/ui-api';
-import { AddressSummary, Grid, Header, Icon, Input, MarginTop, NavButton, Stacked } from '@substrate/ui-components';
+import { AddressSummary, ErrorText, Grid, Header, Icon, Input, MarginTop, NavButton, Stacked, SuccessText } from '@substrate/ui-components';
 import BN from 'bn.js';
 import React from 'react';
 import { Step } from 'semantic-ui-react';
 import { RouteComponentProps } from 'react-router-dom';
+import { Subscription } from 'rxjs';
 import { first, map, switchMap } from 'rxjs/operators';
 
 import { Saved } from './Saved';
@@ -23,11 +24,14 @@ interface Props extends RouteComponentProps<MatchParams> {
 
 type State = {
   amount: BN,
+  error: string | null,
   isAddressValid: boolean,
+  nonceSubscription?: Subscription,
   open: boolean,
   recipientAddress?: string,
   recipientName?: string,
-  step: number
+  step: number,
+  success: string | null
 };
 
 export class SendBalance extends React.PureComponent<Props, State> {
@@ -37,10 +41,23 @@ export class SendBalance extends React.PureComponent<Props, State> {
 
   state: State = {
     amount: new BN(0),
+    error: null,
     isAddressValid: false,
     open: false,
-    step: 1
+    step: 1,
+    success: null
   };
+
+  // FIXME handle subscriptions with react-with-observable
+  componentWillUnmount () {
+    const { nonceSubscription } = this.state;
+
+    nonceSubscription && nonceSubscription.unsubscribe();
+  }
+
+  isValidAddress = (address: string) => {
+    return address[0] === '5' && address.length === 48;
+  }
 
   onChangeAmount = ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({
@@ -79,30 +96,40 @@ export class SendBalance extends React.PureComponent<Props, State> {
     const senderAddress = match.params.currentAddress;
     const senderPair = keyring.getPair(senderAddress);
 
-    // retrieve nonce for the account
-    api.query.system
-      .accountNonce(senderAddress)
-      .pipe(
-         first(),
-         // pipe nonce into transfer
-         switchMap(nonce =>
-           api.tx.balances
-             // create transfer
-             .transfer(recipientAddress, amount)
-             // sign the transaction
-             .sign(senderPair, { nonce })
-             // send the transaction
-             .send()
-         )
-      )
-      // subscribe to overall result
-      .subscribe(({ status, type }) => {
-        if (type === 'Finalised') {
-          console.log('Completed at block hash', status.asFinalised.toHex());
-        } else {
-          console.log(`Staus of transfer: ${type}`);
-        }
+    try {
+      // retrieve nonce for the account
+      const nonceSubscription = api.query.system
+        .accountNonce(senderAddress)
+        .pipe(
+           first(),
+           // pipe nonce into transfer
+           switchMap(nonce =>
+             api.tx.balances
+               // create transfer
+               .transfer(recipientAddress, amount)
+               // sign the transaction
+               .sign(senderPair, { nonce })
+               // send the transaction
+               .send()
+           )
+        )
+        // subscribe to overall result
+        .subscribe(({ status, type }) => {
+          if (type === 'Finalised') {
+            this.onSuccess(`Completed at block hash ${status.asFinalised.toHex()}`);
+          } else if (type === 'Dropped' || type === 'Usurped') {
+            this.onError(`${type} at ${status.asFinalised.toHex}`);
+          } else {
+            console.log(`Status of transfer: ${type}...`);
+          }
+        });
+
+      this.setState({
+        nonceSubscription
       });
+    } catch (error) {
+      this.onError(error);
+    }
   }
 
   openSelectAccountsModal = () => {
@@ -111,8 +138,12 @@ export class SendBalance extends React.PureComponent<Props, State> {
     });
   }
 
-  isValidAddress = (address: string) => {
-    return address[0] === '5' && address.length === 48;
+  private onError = (value: string | null) => {
+    this.setState({ error: value, success: null });
+  }
+
+  private onSuccess = (value: string | null) => {
+    this.setState({ error: null, success: value });
   }
 
   render () {
@@ -156,6 +187,8 @@ export class SendBalance extends React.PureComponent<Props, State> {
                   </Step.Content>
                 </Step>
               </Step.Group>
+              {this.renderSuccess()}
+              {this.renderError()}
             </Stacked>
           </Grid.Column>
 
@@ -164,6 +197,26 @@ export class SendBalance extends React.PureComponent<Props, State> {
           </Grid.Column>
         </Grid.Row>
       </Grid>
+    );
+  }
+
+  renderError () {
+    const { error } = this.state;
+
+    return (
+      <ErrorText>
+        {error || null}
+      </ErrorText>
+    );
+  }
+
+  renderSuccess () {
+    const { success } = this.state;
+
+    return (
+      <SuccessText>
+        {success || null}
+      </SuccessText>
     );
   }
 }

--- a/packages/transfer-app/src/SendBalance.tsx
+++ b/packages/transfer-app/src/SendBalance.tsx
@@ -89,7 +89,7 @@ export class SendBalance extends React.PureComponent<Props, State> {
            api.tx.balances
              // create transfer
              .transfer(recipientAddress, amount)
-             // sign the transcation
+             // sign the transaction
              .sign(senderPair, { nonce })
              // send the transaction
              .send()

--- a/packages/ui-api/src/ApiGate.tsx
+++ b/packages/ui-api/src/ApiGate.tsx
@@ -7,9 +7,10 @@ import { ChainProperties } from '@polkadot/types';
 import keyring from '@polkadot/ui-keyring';
 import React from 'react';
 import { Observable, zip } from 'rxjs';
-import { first, map } from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 
 import { ApiContext } from './ApiContext';
+import { isTestChain } from './util';
 
 interface State {
   isReady: boolean;
@@ -23,16 +24,19 @@ export class ApiGate extends React.PureComponent {
     // Get info about the current chain
     zip(
       this.api.isReady,
+      (this.api.rpc.system.chain()),
       // FIXME Correct types should come from @polkadot/api to avoid type assertion
       (this.api.rpc.system.properties() as unknown as Observable<ChainProperties>)
     ).pipe(
-      map(([_, properties]) => properties),
-      first()
-    ).subscribe((properties) => {
+      take(2)
+    ).subscribe((chainInfo) => {
+      const chain = chainInfo[1];
+      const properties = chainInfo[2];
       const networkId = properties.get('networkId') || 42;
 
       // Setup keyring (loadAll) only after prefix has been set
       keyring.setAddressPrefix(networkId);
+      keyring.setDevMode(isTestChain(chain || ''));
       keyring.loadAll();
 
       this.setState({ isReady: true });

--- a/packages/ui-api/src/ApiGate.tsx
+++ b/packages/ui-api/src/ApiGate.tsx
@@ -7,7 +7,6 @@ import { ChainProperties } from '@polkadot/types';
 import keyring from '@polkadot/ui-keyring';
 import React from 'react';
 import { Observable, zip } from 'rxjs';
-import { first, map, takeLast } from 'rxjs/operators';
 
 import { ApiContext } from './ApiContext';
 import { isTestChain } from './util';
@@ -33,7 +32,7 @@ export class ApiGate extends React.PureComponent {
 
       // Setup keyring (loadAll) only after prefix has been set
       keyring.setAddressPrefix(networkId);
-      keyring.setDevMode(isTestChain(chain || ''));
+      keyring.setDevMode(isTestChain(chain.toString() || ''));
       keyring.loadAll();
 
       this.setState({ isReady: true });

--- a/packages/ui-api/src/ApiGate.tsx
+++ b/packages/ui-api/src/ApiGate.tsx
@@ -7,7 +7,7 @@ import { ChainProperties } from '@polkadot/types';
 import keyring from '@polkadot/ui-keyring';
 import React from 'react';
 import { Observable, zip } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { first, map, takeLast } from 'rxjs/operators';
 
 import { ApiContext } from './ApiContext';
 import { isTestChain } from './util';
@@ -27,11 +27,8 @@ export class ApiGate extends React.PureComponent {
       (this.api.rpc.system.chain()),
       // FIXME Correct types should come from @polkadot/api to avoid type assertion
       (this.api.rpc.system.properties() as unknown as Observable<ChainProperties>)
-    ).pipe(
-      take(2)
-    ).subscribe((chainInfo) => {
-      const chain = chainInfo[1].toString();
-      const properties = chainInfo[2];
+    )
+    .subscribe(([_, chain, properties]) => {
       const networkId = properties.get('networkId') || 42;
 
       // Setup keyring (loadAll) only after prefix has been set

--- a/packages/ui-api/src/ApiGate.tsx
+++ b/packages/ui-api/src/ApiGate.tsx
@@ -7,7 +7,7 @@ import { ChainProperties } from '@polkadot/types';
 import keyring from '@polkadot/ui-keyring';
 import React from 'react';
 import { Observable, zip } from 'rxjs';
-import { map, take } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 
 import { ApiContext } from './ApiContext';
 import { isTestChain } from './util';
@@ -30,7 +30,7 @@ export class ApiGate extends React.PureComponent {
     ).pipe(
       take(2)
     ).subscribe((chainInfo) => {
-      const chain = chainInfo[1];
+      const chain = chainInfo[1].toString();
       const properties = chainInfo[2];
       const networkId = properties.get('networkId') || 42;
 

--- a/packages/ui-api/src/util/index.ts
+++ b/packages/ui-api/src/util/index.ts
@@ -1,0 +1,9 @@
+// Copyright 2017-2019 @polkadot/ui-api authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import isTestChain from './isTestChain';
+
+export {
+  isTestChain
+};

--- a/packages/ui-api/src/util/isTestChain.ts
+++ b/packages/ui-api/src/util/isTestChain.ts
@@ -1,0 +1,17 @@
+// Copyright 2017-2019 @polkadot/ui-api authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { isUndefined } from '@polkadot/util';
+
+const re = new RegExp('(dev|loc)', 'i');
+
+export default function isTestChain (chain?: string): boolean {
+  if (isUndefined(chain)) {
+    return false;
+  }
+
+  const match = re.test(chain.toString().toLowerCase());
+
+  return match ? true : false;
+}

--- a/packages/ui-api/src/util/isTestChain.ts
+++ b/packages/ui-api/src/util/isTestChain.ts
@@ -4,7 +4,7 @@
 
 import { isUndefined } from '@polkadot/util';
 
-const re = new RegExp('(dev|loc)', 'i');
+const re = new RegExp('(Development|Local)', 'i');
 
 export default function isTestChain (chain?: string): boolean {
   if (isUndefined(chain)) {

--- a/packages/ui-components/src/AddressSummary/AddressSummary.tsx
+++ b/packages/ui-components/src/AddressSummary/AddressSummary.tsx
@@ -4,11 +4,9 @@
 
 import IdentityIcon from '@polkadot/ui-identicon';
 import { KeyringAddress } from '@polkadot/ui-keyring/types';
-import BN from 'bn.js';
 import React from 'react';
 
 import { Name, Stacked, StackedHorizontal } from '../Shared.styles';
-import BalanceDisplay from '../Balance';
 
 type OrientationTypes = 'horizontal' | 'vertical';
 type SizeTypes = 'tiny' | 'small' | 'medium' | 'large';
@@ -19,7 +17,6 @@ type SummaryStyles = {
 
 type Props = {
   address?: string | KeyringAddress,
-  balance?: BN,
   name?: string,
   orientation?: OrientationTypes,
   size?: SizeTypes
@@ -30,7 +27,7 @@ const PLACEHOLDER_ADDRESS = '5'.padEnd(16, 'x');
 
 export class AddressSummary extends React.PureComponent<Props> {
   render () {
-    const { address, balance, name, orientation = 'vertical', size = 'medium' } = this.props;
+    const { address, name, orientation = 'vertical', size = 'medium' } = this.props;
     let styles: SummaryStyles = { identiconSize: 16, nameSize: '14px' };
 
     switch (size) {
@@ -55,7 +52,6 @@ export class AddressSummary extends React.PureComponent<Props> {
         <Stacked>
           <IdentityIcon value={address as string || PLACEHOLDER_ADDRESS} theme={'substrate'} size={styles.identiconSize} />
           <Name fontSize={styles.nameSize}> {name || PLACEHOLDER_NAME} </Name>
-          <BalanceDisplay balance={balance} />
         </Stacked>
       );
     } else {
@@ -63,7 +59,6 @@ export class AddressSummary extends React.PureComponent<Props> {
         <StackedHorizontal justify='space-around'>
           <IdentityIcon value={address as string || PLACEHOLDER_ADDRESS} theme={'substrate'} size={styles.identiconSize} />
           <Name fontSize={styles.nameSize}> {name || PLACEHOLDER_NAME} </Name>
-          <BalanceDisplay balance={balance} />
         </StackedHorizontal>
       );
     }


### PR DESCRIPTION
Steps to close:
* [x] integrate development accounts
* [x] send test balance transfer
* [x] manage subscriptions
* [x] manage errors, loading


Also splitting out BalanceDisplay from AddressSummary so they work as independent components. Something storybook was complaining about as well