### PR TITLE
fix: remove react warning message for controlled components

### DIFF
--- a/packages/light-apps/src/Onboarding/CreateNewAccountScreen.tsx
+++ b/packages/light-apps/src/Onboarding/CreateNewAccountScreen.tsx
@@ -33,6 +33,7 @@ export class CreateNewAccountScreen extends React.PureComponent<Props, State> {
     mnemonic: '',
     name: '',
     password: '',
+    rewritePhrase: '',
     step: 'create'
   };
 


### PR DESCRIPTION
Playing around, I found this little error. It shows a react error message about a component being switched from uncontrolled to controlled.

Repro:
- fresh install, with no accounts, Onboarding shows
- give a name/password to the account, click on "Next"
- in the "Rewrite Mnemonic Below" field, write something
- The following message appears:
`index.js:1446 Warning: A component is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components`