### PR TITLE
fix(ui-components): remove min-height: 100%; from Stacked

### DIFF
--- a/packages/ui-components/src/Shared.styles.ts
+++ b/packages/ui-components/src/Shared.styles.ts
@@ -141,7 +141,6 @@ export const Stacked = styled.div<StackProps>`
   flex: 1;
   flex-direction: column;
   justify-content: ${props => props.justify || 'center'};
-  min-height: 100%;
   text-align: ${props => props.textAlign || 'center'};
 `;
 


### PR DESCRIPTION
Fix broken display on Firefox

before:
![image](https://user-images.githubusercontent.com/5739676/55332357-803f4080-5495-11e9-95f1-967b0156488e.png)

haven't tested if my change breaks stuff on other screens
