### PR TITLE
Proposal: Move MatchParams.currentAccount logic to UserContext

### DIFF
--- a/packages/ui-common/src/ContextGate.tsx
+++ b/packages/ui-common/src/ContextGate.tsx
@@ -15,6 +15,7 @@ import { AppContext, System } from './AppContext';
 import { isTestChain } from './util';
 import { AlertsContextProvider } from './AlertsContext';
 import { TxQueueContextProvider } from './TxQueueContext';
+import { UserContextProvider } from './UserContext';
 
 interface State {
   isReady: boolean;
@@ -129,7 +130,9 @@ export function ContextGate (props: { children: React.ReactNode }) {
           keyring,
           system
         }}>
-          {children}
+          <UserContextProvider>
+            {children}
+          </UserContextProvider>
         </AppContext.Provider>
       </TxQueueContextProvider>
     </AlertsContextProvider>

--- a/packages/ui-common/src/UserContext.tsx
+++ b/packages/ui-common/src/UserContext.tsx
@@ -1,0 +1,47 @@
+// Copyright 2018-2019 @paritytech/substrate-light-ui authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import React, { useContext, useState, createContext, useEffect } from 'react';
+import { AppContext } from '.';
+
+export const UserContext = createContext({
+  bondingPreferences: {},
+  isNominating: false,
+  setBondingPreferences: (bondingPreferences: any) => { console.error('No context provider found above in the tree.'); },
+  setIsNominating: (isNominating: boolean) => { console.error('No context provider found above in the tree.'); }
+});
+
+interface Props {
+  children: any;
+}
+
+// Provides context about the :currentAccount at various routes for all packages
+export function UserContextProvider (props: Props) {
+  const { api } = useContext(AppContext);
+  const [{ bondingPreferences, isNominating }, setUserContext] = useState({ bondingPreferences: {}, isNominating: false });
+
+  useEffect(() => {
+
+  });
+
+  const setBondingPreferences = (bondingPreferences: any) => {
+    setUserContext({
+      bondingPreferences,
+      isNominating
+    });
+  };
+
+  const setIsNominating = (isNominating: boolean) => {
+    setUserContext({
+      bondingPreferences,
+      isNominating
+    });
+  };
+
+  return (
+    <UserContext.Provider value={{ bondingPreferences, isNominating, setBondingPreferences, setIsNominating }}>
+      {props.children}
+    </UserContext.Provider>
+  );
+}

--- a/packages/ui-common/src/index.ts
+++ b/packages/ui-common/src/index.ts
@@ -6,4 +6,5 @@ export * from './AlertsContext';
 export * from './AppContext';
 export * from './ContextGate';
 export * from './TxQueueContext';
+export * from './UserContext';
 export * from './util';


### PR DESCRIPTION
## Problem
Currently we deal with a notion of `currentAccount` by passing it as a match param via react-router. This works and it's easy but has some limitations fwiw:

a. we need to destructure it over and over as `location.pathname.split('/')[2]`
b. we don't actually have any way to pass account specific details across all the subpackages. e.g. I can get some staking info in my accounts app, but then to show parts of that in IdentityHeader for example, I need to duplicate that same subscription.

## Proposal
By moving this logic to a UserContext, we can be more DRY. The downside I can see atm is that it would introduce another slightly repetitive pattern:
```
history.push(`/transfer/`)
setCurrentAccount()
```
but this is still less redundant as you only need to `setCurrentAccount` when you know it's changed, as opposed to passing it through everytime just to match the pattern for the unflexible desctructuring pattern mentioned in `a.`.

I made a Draft PR here to display just the gist of the idea. This came up as I was working on accounts-app and realized a lot of headaches can be relieved with this architecture. Thought I'd post it as a proposal first though because it would be a fairly sizeable refactor so in case there are holes to this that I'm not seeing.