### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=paritytech/substrate-light-ui)](https://dependabot.com)
 <a href="https://codeclimate.com/github/paritytech/substrate-light-ui/maintainability"><img src="https://api.codeclimate.com/v1/badges/bdff9a9d1f154523d3b9/maintainability" /></a>
 
-# Substrate Light UI
+# ~Substrate Light UI~ Polkadot Nominator Wallet
 
-Light client focused user interface for the Polkadot and Substrate networks.
+~Light client focused user interface for the Polkadot and Substrate networks.~
 
-The Light UI is meant to be **an intuitive interface for beginner users** to easily interact with the main components of various Substrate chains.
+~The Light UI is meant to be **an intuitive interface for beginner users** to easily interact with the main components of various Substrate chains.~
+
+Pivot: This is a wallet optimized for Polkadot Nominators. Polkadot's security is roughly proportional to the ratio of DOTs that are staked, and our wallet strives to make this process as seamless and dummy proof as possible.
 
 ## [» Download the latest release (macOS only) «](https://github.com/paritytech/substrate-light-ui/releases/latest)
 
@@ -23,7 +25,7 @@ As of v0.1.0, the main functions are as follows:
 
 And here is a rough roadmap of what's coming next (see the [0.2.0 milestone](https://github.com/paritytech/substrate-light-ui/milestone/1) for details):
 
-- [ ] Staking/Nominating/Voting democracy - stake tokens, nominate validators, and vote for proposals regarding the the current chain (see [#62](https://github.com/paritytech/substrate-light-ui/issues/62)).
+- [x] Staking/Nominating/Voting democracy - stake tokens, nominate validators, and vote for proposals regarding the the current chain (see [#62](https://github.com/paritytech/substrate-light-ui/issues/62)).
 
 - [ ] Light UI will be bundled with a light client - it won't rely on a remote node.
 


### PR DESCRIPTION
## Rationale
"Substrate Light UI" is not really solving a problem for anyone, and it also doesn't describe the project accurately. At the beginning of the project, we were prompted to build a "Fether for Substrate" seems about right and ran with it, but at this point, we've agreed this really doesn't make any sense at all. Teams building their projects on Substrate are going to build their own UI's as they should, and bundling a light client (once it is done once), won't be such a cumbersome task that we need a whole project dedicated toward bootstrapping that effort.

"Polkadot Nominator Wallet" is more aligned as to what we aim to do with this project, and is solving a real problem for a very specific set of users. This can still be shipped with a bundled light client in the future.

Framing the project this way also differentiates from /apps significantly. 

* Apps is built to have complete feature parity with everything made available through a Polkadot node, it is not a "commercial product" per say, but a really really robust developer tool for technical folks experimenting with building parachains on Polkadot. 
* Institutional-level Validators will not be using a UI for the most part. 
* Trying to become a nominator today especially on a value bearing chain is an absolutely nerve-wracking experience, enough to deter a whole lot of DOT holders from doing so. More idle DOTs === less secure network. 

* Polkadot Nominator Wallet is built to provide the minimal set of features required for DOT holders who don't need the DOTs to lease a parachain slot, nor are they using the DOTs for active governance participation. 



