### PR TITLE
feat: Inject to notify page that extension is present

### DIFF
--- a/packages/extension-app/package.json
+++ b/packages/extension-app/package.json
@@ -21,6 +21,7 @@
     "webpack-extension-manifest-plugin": "^0.5.0"
   },
   "dependencies": {
+    "@polkadot/extension-inject": "^0.14.1",
     "extensionizer": "^1.0.1",
     "web-ext-types": "^3.2.1",
     "webextension-polyfill": "^0.6.0"

--- a/packages/extension-app/src/content/index.ts
+++ b/packages/extension-app/src/content/index.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 /**
- * This file is only injected in http://localhost:3000
+ * This content script is only injected in http://localhost:3000
  */
 
 import extensionizer from 'extensionizer';
@@ -25,3 +25,18 @@ window.addEventListener('message', ({ data, source }): void => {
 
   port.postMessage(data);
 });
+
+// Copied from https://github.com/polkadot-js/extension/blob/ce37e2a8f2c537b7711f501c06fd355de7d5c95c/packages/extension/src/content.ts#L27-L38
+
+// inject our data injector
+const script = document.createElement('script');
+
+script.src = extensionizer.extension.getURL('page.js');
+script.onload = (): void => {
+  // remove the injecting tag when loaded
+  if (script.parentNode) {
+    script.parentNode.removeChild(script);
+  }
+};
+
+(document.head || document.documentElement).appendChild(script);

--- a/packages/extension-app/src/manifest.json
+++ b/packages/extension-app/src/manifest.json
@@ -29,5 +29,6 @@
     "64": "images/icon-64.png",
     "128": "images/icon-128.png"
   },
+  "web_accessible_resources": ["page.js"],
   "content_security_policy": "script-src 'self' blob: 'unsafe-eval' 'wasm-eval'; object-src 'self'"
 }

--- a/packages/extension-app/src/page/index.ts
+++ b/packages/extension-app/src/page/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2019-2020 @paritytech/substrate-light-ui authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+/**
+ * Script to inject to the host webpage.
+ * This file is only injected in http://localhost:3000 (see `content/`)
+ */
+
+import { injectExtension } from '@polkadot/extension-inject';
+import { Injected } from '@polkadot/extension-inject/types';
+
+import pkgJson from '../../package.json';
+
+function enableFn(): Promise<Injected> {
+  return Promise.reject(new Error('Unimplemented'));
+}
+
+injectExtension(enableFn, { name: 'slui', version: pkgJson.version });

--- a/packages/extension-app/webpack.config.js
+++ b/packages/extension-app/webpack.config.js
@@ -31,6 +31,7 @@ function createWebpack({ alias = {}, context }) {
     entry: {
       background: './src/background/index.ts',
       content: './src/content/index.ts',
+      page: './src/page/index.ts',
     },
     mode: ENV,
     output: {

--- a/packages/light-apps/src/ContextGate/ContextGate.tsx
+++ b/packages/light-apps/src/ContextGate/ContextGate.tsx
@@ -69,8 +69,9 @@ function getProvider(env: Env): ProviderInterface {
       return new PostMessageProvider(port);
     }
     default:
-      return process.env.NODE_ENV === 'development'
-        ? // With http://localhost:3000, we deliberatelyuse a PostMessageProvider
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (window as any).injectedWeb3 && (window as any).injectedWeb3.slui
+        ? // If we detect the extension, use PostMessageProvider
           new PostMessageProvider('window')
         : // We fallback to the remote node provided by W3F
           new WsProvider('wss://kusama-rpc.polkadot.io/');


### PR DESCRIPTION
Before: if we were on `localhost:3000` , then use `new PostMessageProvider('window')`
After: if we detect that the extension exists, then use `new PostMessageProvider('window')`

To do so, we inject a `slui` object inside `window.web3Injected`, same as polkadot-js