### PR TITLE
fix(light-apps): Add modal as per Figma

### DIFF
--- a/packages/light-apps/src/Accounts/Accounts.tsx
+++ b/packages/light-apps/src/Accounts/Accounts.tsx
@@ -2,17 +2,29 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { Modal } from '@substrate/ui-components';
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Route, RouteComponentProps } from 'react-router-dom';
 
 import { AddAccount } from './Add';
 import { AccountsOverview } from './Overview';
 
-export function Accounts(): React.ReactElement {
+type Props = RouteComponentProps;
+
+export function Accounts(props: Props): React.ReactElement {
+  const { history } = props;
+
   return (
-    <Switch>
-      <Route path='/accounts/add' component={AddAccount} />
+    <>
+      <Route
+        path='/accounts/add'
+        render={(routeProps): React.ReactElement => (
+          <Modal open onClose={(): void => history.push('/')}>
+            <AddAccount {...routeProps} />
+          </Modal>
+        )}
+      />
       <Route component={AccountsOverview} />
-    </Switch>
+    </>
   );
 }

--- a/packages/light-apps/src/Accounts/Accounts.tsx
+++ b/packages/light-apps/src/Accounts/Accounts.tsx
@@ -21,7 +21,7 @@ export function Accounts(props: Props): React.ReactElement {
       <Route
         path='/accounts/add'
         render={(routeProps): React.ReactElement => (
-          <Modal open onClose={goToAccounts}>
+          <Modal onClose={goToAccounts} open>
             <AddAccount {...routeProps} />
           </Modal>
         )}

--- a/packages/light-apps/src/Accounts/Accounts.tsx
+++ b/packages/light-apps/src/Accounts/Accounts.tsx
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Modal } from '@substrate/ui-components';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Route, RouteComponentProps } from 'react-router-dom';
 
 import { AddAccount } from './Add';
@@ -14,12 +14,14 @@ type Props = RouteComponentProps;
 export function Accounts(props: Props): React.ReactElement {
   const { history } = props;
 
+  const goToAccounts = useCallback((): void => history.push('/'), [history]);
+
   return (
     <>
       <Route
         path='/accounts/add'
         render={(routeProps): React.ReactElement => (
-          <Modal open onClose={(): void => history.push('/')}>
+          <Modal open onClose={goToAccounts}>
             <AddAccount {...routeProps} />
           </Modal>
         )}

--- a/packages/light-apps/src/Routes/Routes.tsx
+++ b/packages/light-apps/src/Routes/Routes.tsx
@@ -2,9 +2,9 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Container, Fab } from '@substrate/ui-components';
+import { Container } from '@substrate/ui-components';
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { Accounts } from '../Accounts';
 import { Signer } from '../Signer';
@@ -13,13 +13,6 @@ import { TxQueueNotifier } from '../TxQueueNotifier';
 export function Routes(): React.ReactElement {
   return (
     <Container>
-      <Route
-        render={(): React.ReactElement => (
-          <Link to='/transfer'>
-            <Fab type='send' />
-          </Link>
-        )}
-      />
       <Switch>
         <Redirect exact from='/' to='/accounts' />
         <Route path='/accounts' component={Accounts} />

--- a/packages/light-apps/src/TopBar/TopBar.tsx
+++ b/packages/light-apps/src/TopBar/TopBar.tsx
@@ -64,16 +64,26 @@ export function TopBar(): React.ReactElement {
   const { chain, header, health } = useContext(SystemContext);
 
   return (
-    <BlackBlock>
-      <Container as='header'>
-        <div className='flex items-center'>
-          {renderLogo()}
-          <ConnectedNodes fluid>
-            {renderHealth(chain, header, health)}
-            <ChooseProvider />
-          </ConnectedNodes>
-        </div>
-      </Container>
-    </BlackBlock>
+    <>
+      <div className='flex'>
+        <BlackBlock className='w-10'>
+          <Link to='/accounts'>Accounts</Link>
+        </BlackBlock>
+        <BlackBlock className='w-10'>
+          <Link to='/transfer'>Transfer</Link>
+        </BlackBlock>
+      </div>
+      <BlackBlock>
+        <Container as='header'>
+          <div className='flex items-center'>
+            {renderLogo()}
+            <ConnectedNodes fluid>
+              {renderHealth(chain, header, health)}
+              <ChooseProvider />
+            </ConnectedNodes>
+          </div>
+        </Container>
+      </BlackBlock>
+    </>
   );
 }


### PR DESCRIPTION
@goldsteinsveta I put all the account creation into a modal. On your own time could you try `yarn start:ui` and tell me if you can work on top of that?

Also added the 2 nav buttons on the TopBar. Note: the `Transfer` link doesn't work now, I'm refactoring the Transfer components inside.